### PR TITLE
Update create_key in LOBE_HCPLS.py

### DIFF
--- a/heuristics/LOBE_HCPLS.py
+++ b/heuristics/LOBE_HCPLS.py
@@ -3,7 +3,7 @@ import os
 # Adaptation of HCP-Lifespan protocol to the pediatric epilepsy imaging (LOBE) study
 # Requires tar2bids > v0.0.5h for vNav clean-up
 
-def create_key(template, outtype=('nii.gz'), annotation_classes=None):
+def create_key(template, outtype=('nii.gz',), annotation_classes=None):
     if template is None or not template:
         raise ValueError('Template must be a valid format string')
     return (template, outtype, annotation_classes)


### PR DESCRIPTION
By changing `outtype=('nii.gz')` (string type) to `outtype=('nii.gz',)` (tuple type), heuristic was able to work for new tar2bids versions.

Code-wise, there may have been some changes between heudiconv `v0.11.6` and `v0.13.1` that previously allowed for the string-type to be accepted.